### PR TITLE
Add project documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
-# Very quick
+# xlsx-quick-append-rs
+
 [![Build maturin wheels](https://github.com/krakotay/xlsx-quick-append-rs/actions/workflows/release.yml/badge.svg?branch=master)](https://github.com/krakotay/xlsx-quick-append-rs/actions/workflows/release.yml)
+
+A small project for quickly updating `.xlsx` workbooks from Rust or Python.
+It consists of two crates:
+
+* **rust-core** – the core library that works directly with spreadsheet XML.
+* **python-bindings** – Python wrapper built with `pyo3` and `maturin`.
+
+The library lets you append rows or tables, modify individual cells and
+save the workbook back to disk without loading the entire file into memory.
+
+For detailed usage examples see [docs/usage.md](docs/usage.md).

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,0 +1,20 @@
+# Project overview
+
+`xlsx-quick-append-rs` is organised as a Cargo workspace containing two crates:
+
+- `rust-core` implements the logic for editing XLSX files. It works at the XML
+  level inside the ZIP archive without requiring heavy dependencies.
+- `python-bindings` exposes the same functionality to Python via the `pyo3`
+  ecosystem and is published as the `xlsx_append_py` package.
+
+The `rust-core` crate defines the `XlsxEditor` type and helper function
+`scan` for listing sheet names. The editor can append rows or tables to a
+worksheet, insert a table starting from an arbitrary cell and update individual
+cells. Modified content can be saved to a new file or overwrite the
+original workbook.
+
+The Python bindings mirror this API in the `PyXlsxEditor` class and a
+`scan_excel` function. Example scripts can be found in
+[`python-bindings/tests`](../python-bindings/tests).
+
+A sample spreadsheet for tests is located in the `test/` directory.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,58 @@
+# Usage Guide
+
+This document describes how to use the `xlsx-quick-append-rs` project.
+
+## Rust library
+
+The core functionality resides in the `rust-core` crate. It exposes the
+`XlsxEditor` type which can open an existing `.xlsx` file and modify its
+contents.
+
+### Opening a sheet
+```rust
+use rust_core::{XlsxEditor, scan};
+
+let sheet_names = scan("test.xlsx")?;
+let mut editor = XlsxEditor::open("test.xlsx", &sheet_names[0])?;
+```
+
+### Adding data
+Append a row to the end of the current worksheet:
+```rust
+editor.append_row(["Hello", "World"])?;
+```
+
+Insert a table starting from a specific cell:
+```rust
+let rows = vec![vec!["1"], vec!["2"]];
+editor.append_table_at("C1", rows)?;
+```
+
+Set the value of an individual cell:
+```rust
+editor.set_cell("A1", "Some text")?;
+```
+
+### Saving
+Write the modified workbook to a new file:
+```rust
+editor.save("output.xlsx")?;
+```
+
+## Python bindings
+
+Bindings are provided in the `python-bindings` crate. After building with
+`maturin`, the package `xlsx_append_py` offers an interface similar to the
+Rust API.
+
+Example:
+```python
+from xlsx_append_py import scan_excel, PyXlsxEditor
+
+sheets = scan_excel("tests/test_sum.xlsx")
+editor = PyXlsxEditor("tests/test_sum.xlsx", sheets[0])
+editor.append_row(["Hello", "World"])
+editor.save("tests/result.xlsx")
+```
+
+Refer to `python-bindings/tests` for more examples.


### PR DESCRIPTION
## Summary
- rewrite README with basic description of the crates
- add a `docs` directory with usage instructions and an overview of the workspace

## Testing
- `cargo test --workspace`
- `python -m pytest -q` *(fails: FileNotFoundError for `tests/test_sum.xlsx`)*

------
https://chatgpt.com/codex/tasks/task_e_68753cb619a083218a308fb9446a0c1c